### PR TITLE
Started Roboteq Node

### DIFF
--- a/yeti_snowplow/CMakeLists.txt
+++ b/yeti_snowplow/CMakeLists.txt
@@ -152,6 +152,10 @@ add_executable(navigation_pid src/navigation_pid.cpp src/containers/Target.cpp s
 add_dependencies(navigation_pid yeti_snowplow_generate_messages_cpp)
 target_link_libraries(navigation_pid ${catkin_LIBRARIES})
 
+add_executable(roboteq src/roboteq.cpp)
+add_dependencies(roboteq yeti_snowplow_generate_messages_cpp)
+target_link_libraries(roboteq ${catkin_LIBRARIES})
+
 add_executable(waypoint_selection src/waypoint_selection.cpp src/containers/Target.cpp src/containers/LocationPoint.cpp)
 add_dependencies(waypoint_selection yeti_snowplow_generate_messages_cpp)
 target_link_libraries(waypoint_selection ${catkin_LIBRARIES})

--- a/yeti_snowplow/launch/roboteq_test.launch
+++ b/yeti_snowplow/launch/roboteq_test.launch
@@ -1,0 +1,12 @@
+<launch>
+  <param name="serial_port" value="/dev/ttyUSB0" />
+  <!-- I'm pretty sure these are supposed to be in meters, but there is little documentation -->
+  <param name="wheel_diameter" value="0.30" />
+  <!--<param name="wheel_base_length" value="0.63" />  -->
+  <param name="wheel_base_length" value="2.0" /> <!-- Set to 2 so that channel B's speed isn't halved -->
+  <node pkg="ax2550" type="ax2550_node" name="ax2550_node" />
+
+  <node pkg="joy" type="joy_node" name="joy_node" />
+  <node pkg="yeti_snowplow" type="joystick" name="joystick" />
+  <node pkg="yeti_snowplow" type="roboteq" name="roboteq" output="screen" />
+</launch>

--- a/yeti_snowplow/package.xml
+++ b/yeti_snowplow/package.xml
@@ -46,10 +46,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>ax2550</build_depend>
+  <!--<build_depend>lms1xx</build_depend>-->
   <run_depend>joy</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>ax2550</run_depend>
+  <!--<run_depend>lms1xx</run_depend>-->
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/yeti_snowplow/src/joystick.cpp
+++ b/yeti_snowplow/src/joystick.cpp
@@ -36,7 +36,23 @@ void joystickCallback(const sensor_msgs::Joy::ConstPtr& joy){
 	msg.B = BUTTON_B;
 	msg.X = BUTTON_X;
 	msg.Y = BUTTON_Y;
-	// ROS_INFO("%s", strs.str().c_str());
+	msg.LB = BUTTON_LB;
+	msg.RB = BUTTON_RB;
+	msg.Back = BUTTON_BACK;
+	msg.Start = BUTTON_START;
+	msg.Guide = BUTTON_GUIDE;
+	msg.LS = BUTTON_LS;
+	msg.RS = BUTTON_RS;
+
+	msg.LeftStick_LR = AXIS_L_LR;
+	msg.LeftStick_UD = AXIS_L_UD;
+	msg.RightStick_LR = AXIS_R_LR;
+	msg.RightStick_UD = AXIS_R_UD;
+	msg.LT = AXIS_LT;
+	msg.RT = AXIS_RT;
+	msg.DPad_LR = AXIS_DPAD_LR;
+	msg.DPad_UD = AXIS_DPAD_UD;
+
 	joystickPub.publish(msg);
 }
 

--- a/yeti_snowplow/src/roboteq.cpp
+++ b/yeti_snowplow/src/roboteq.cpp
@@ -1,0 +1,31 @@
+#include "ros/ros.h"
+#include "geometry_msgs/Twist.h"
+#include "yeti_snowplow/joystick.h"
+
+ros::Publisher roboteqPub;
+
+void joystickCallback(const yeti_snowplow::joystick::ConstPtr& joy){	
+	/* This fires every time a button is pressed/released
+	and when an axis changes (even if it doesn't leave the
+	deadzone). */
+	
+	geometry_msgs::Twist msg;
+	msg.angular.z = joy->A ? joy->LeftStick_UD : 0; //left
+	msg.linear.x = joy->A ? joy->LeftStick_UD : 0; //right
+	ROS_INFO("%s left=%f right=%f", joy->A ? "on" : "off", msg.angular.z, msg.linear.x);
+	roboteqPub.publish(msg);
+}
+
+int main(int argc, char **argv){
+	ros::init(argc, argv, "roboteq");
+
+	ros::NodeHandle n;
+
+	roboteqPub = n.advertise<geometry_msgs::Twist>("cmd_vel", 1000);
+
+	ros::Subscriber joystickSub = n.subscribe("joystick", 1000, joystickCallback);
+
+	ros::spin();
+	
+	return 0;
+}


### PR DESCRIPTION
Got the Roboteq node working. Note the parameters in the launch file are required. The roboteq connects (on Laptop 4 anyway) to `/dev/ttyUSB0`. There's almost no documentation, even in the code, but both `wheel_diameter` and `wheel_base_length` are used and will be set to values we probably don't want if you don't set them yourself. The code mentions "mps", which I'm assuming is "meters per second" so those values are probably supposed to be in meters. However, it looks like this node was intended for car style turning, not skid steering, so there's some oddities to make it work:

- The ax2550 node subscribes to the `cmd_vel` topic with `geometry_msgs/Twist` messages. Because it was designed for turn steering, `msg.linear.x` was supposed to be speed and `msg.angular.z` was supposed to be direction. However, we're using skid steering, so that translates into `msg.linear.x` -> Channel A -> right wheels and `msg.angular.z` -> Channel B -> left wheels. Fortunately, only the Roboteq node has to worry about this.
- `wheel_base_length` needs to be set to `2.0` so the speed of the left wheels (channel B) isn't adjusted. This is because that value is divided by 2 and multiplied by `msg.angular.z` (so 2 divided by 2 is 1, and multiplying by 1 does nothing).
- I'm honestly not sure what `wheel_diameter` is used for. The ax2550 node factors it into the calculation of the wheel speed, but then it uses some magic numbers and I don't know why (see lines 59-64 in ax2550_node.cc). So I have it set to the size of our wheels in meters (0.30 meters).

Run `rosdep install yeti_snowplow` to install the new dependencies. 

#10 Added setting the rest of the joystick parameters for the `joystick` topic. I forgot this before somehow.
#9 Run the `roboteq_test` launch file to test it out. The A button enables and the left stick goes forward and backward. If you get a permission denied error when it tries to connect to the Roboteq, run `sudo adduser <your-username> dialout` and then logout and back in.